### PR TITLE
Add new checkpoint colors for new laps

### DIFF
--- a/config/challenges.xml
+++ b/config/challenges.xml
@@ -862,14 +862,14 @@
 	</challenge>
 
 	<challenge name="Test 4 laps, hud" ver="1" difficulty="2" type="7" 
-			descr="Test Challenge 4, 2 laps.
+			descr="Test Challenge 4, 4 laps.
 			Allow checkpoint arrow,beam and abs,tcs. Deny track's ghost.">
 		<cartype names="Extreme" />
 			<sim abs="1" tcs="1" />
 			<hud chkArrow="1" chkBeam="1" trkGhost="0" />
 		<pass avgPos="5" />
 		<tracks>
-			<t name="TestC4-ow"  laps="2" passPoints="5.0" />
+			<t name="TestC4-ow"  laps="4" passPoints="5.0" />
 		</tracks>
 	</challenge>
 

--- a/data/materials/scene/road.mat
+++ b/data/materials/scene/road.mat
@@ -5,8 +5,6 @@ material checkpoint
 	diffuseMap checkpoint.png
 	ambient 0.1 0.1 0.1
 	diffuse 0.1 0.1 0.1
-	specular 0.2 0.4 0.2  32 //x4
-	emissive 0.1 11.0 0.1
 
 	depth_write off
 	scene_blend alpha_blend
@@ -16,6 +14,39 @@ material checkpoint
 	cull_hardware none
 	twoside_diffuse true
 }
+
+// a normal checkpoint which is not the start/finish point
+material checkpoint_normal
+{
+	parent checkpoint
+	specular 0.2 0.4 0.2  32 //x4
+	emissive 0.1 11.0 0.1
+}
+
+// start/finish point; does not end race
+material checkpoint_lap
+{
+	parent checkpoint
+	specular 0.2 0.4 0.4  32 //x4
+	emissive 0.1 11.0 11.0
+}
+
+// start/finish point; last lap begins after passing it
+material checkpoint_lastlap
+{
+	parent checkpoint
+	specular 0.2 0.2 0.4  32 //x4
+	emissive 0.1 0.1 11.0 
+}
+
+// the very last checkpoint; ends race after passing
+material checkpoint_finish
+{
+	parent checkpoint
+	specular 0.4 0.2 0.2  32 //x4
+	emissive 11.0 0.1 0.1
+}
+
 
 
 material road_terrain

--- a/source/ogre/CarModel_Create.cpp
+++ b/source/ogre/CarModel_Create.cpp
@@ -419,6 +419,8 @@ void CarModel::Create()
 	{
 		entNextChk = mSceneMgr->createEntity("Chk"+strI, "check.mesh");
 		entNextChk->setRenderQueueGroup(RQG_Weather);  entNextChk->setCastShadows(false);
+		MaterialPtr mtr = MaterialManager::getSingleton().getByName("checkpoint_normal");
+		entNextChk->setMaterial(mtr);
 		ndNextChk = mSceneMgr->getRootSceneNode()->createChildSceneNode();
 		ndNextChk->attachObject(entNextChk);  entNextChk->setVisibilityFlags(RV_Hud);
 		ndNextChk->setVisible(false);

--- a/source/ogre/CarModel_Update.cpp
+++ b/source/ogre/CarModel_Update.cpp
@@ -55,10 +55,26 @@ void CarModel::UpdNextCheck()
 	if (pApp->scn->road->mChks.empty())  return;
 
 	Vector3 p;
+	MaterialPtr mtr;
 	if (iNumChks == pApp->scn->road->mChks.size() && iCurChk != -1)
+	{
+		bool hasLaps = pSet->game.local_players > 1 || pSet->game.champ_num >= 0 || pSet->game.chall_num >= 0; // FIXME: || app->mClient;
+		int lap = pGame->timer.GetCurrentLap(iIndex) + 1;
+		if (hasLaps && (lap == pSet->game.num_laps - 1))
+			mtr = MaterialManager::getSingleton().getByName("checkpoint_lastlap");
+		else if (hasLaps && (lap == pSet->game.num_laps))
+			mtr = MaterialManager::getSingleton().getByName("checkpoint_finish");
+		else
+			mtr = MaterialManager::getSingleton().getByName("checkpoint_lap");
+		entNextChk->setMaterial(mtr);
 		p = vStartPos;  // finish
+	}
 	else
+	{
 		p = pApp->scn->road->mChks[iNextChk].pos;
+		mtr = MaterialManager::getSingleton().getByName("checkpoint_normal");
+		entNextChk->setMaterial(mtr);
+	}
 		
 	p.y -= gPar.chkBeamSy;  // lower
 	ndNextChk->setPosition(p);


### PR DESCRIPTION
This PR adds new checkpoint colors for the finish line and replaces the default color.

New color key:
- Normal checkpoint: green
- Finish line, new lap: cyan
- Finish line, last lap ahead (only in races with lap limit): blue
- Finish line, ends race (only in races with lap limit): red

I tested it myself and it seems to work. There is 1 FIXME in the code, please check if that line is the proper way to find out wheather the game uses laps or not.
