### PR TITLE
Disable bullet profiling if BT_NO_PROFILE is defined

### DIFF
--- a/source/ogre/CHud.cpp
+++ b/source/ogre/CHud.cpp
@@ -6,7 +6,9 @@
 #include "common/data/SceneXml.h"
 #include "common/CScene.h"
 #include "../vdrift/settings.h"
+#ifndef BT_NO_PROFILE
 #include <LinearMath/btQuickprof.h>
+#endif // BT_NO_PROFILE
 #include <OgreManualObject.h>
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
@@ -151,7 +153,7 @@ void CHud::UpdDbgTxtClr()
 	}
 }
 
-
+#ifndef BT_NO_PROFILE
 ///  Bullet profiling text
 //--------------------------------------------------------------------------------------------------------------
 
@@ -214,3 +216,4 @@ void CHud::bltDumpAll(std::stringstream& os)
 
 	CProfileManager::Release_Iterator(profileIterator);
 }
+#endif // BT_NO_PROFILE

--- a/source/ogre/CHud.h
+++ b/source/ogre/CHud.h
@@ -154,7 +154,9 @@ public:
 	//  string utils
 	Ogre::String StrClr(Ogre::ColourValue c);
 
+#ifndef BT_NO_PROFILE
 	//  bullet debug text
 	void bltDumpRecursive(class CProfileIterator* profileIterator, int spacing, std::stringstream& os);
 	void bltDumpAll(std::stringstream& os);
+#endif // BT_NO_PROFILE
 };

--- a/source/ogre/Hud_Update.cpp
+++ b/source/ogre/Hud_Update.cpp
@@ -597,6 +597,7 @@ void CHud::Update(int carId, float time)
 	}
 
 
+#ifndef BT_NO_PROFILE
 	//  bullet profiling text  --------
 	static bool oldBltTxt = false;
 	if (ov[1].oU)
@@ -616,6 +617,7 @@ void CHud::Update(int carId, float time)
 			ov[1].oU->setCaption("");
 	}
 	oldBltTxt = pSet->bltProfilerTxt;
+#endif // BT_NO_PROFILE
 
 	
 	//  wheels slide, susp bars  --------


### PR DESCRIPTION
Fixes build with Bullet 2.85.

`CProfileManager` and `CProfileIterator` were disabled in upstream Bullet
https://github.com/bulletphysics/bullet3/commit/25a1714754572ce07b458e0cbaa6b84932619140
for version 2.84+.

---

I've confirmed that this builds fine ([same patch used on Mageia](http://svnweb.mageia.org/packages/cauldron/stuntrally/current/SOURCES/stuntrally-2.6-mga-bullet-2.85-no-profile.patch?view=markup&pathrev=1063722) modulo the conditional header inclusion I had forgotten, but it doesn't appear to be needed for any other class/method), though I haven't tested the game itself yet (will do tonight).

Without this patch, the build fails with:
```
[ 77%] Building CXX object source/CMakeFiles/stuntrally.dir/ogre/CHud.cpp.o
cd /home/iurt/rpmbuild/BUILD/stuntrally-2.6/build/source && /usr/bin/c++   -DOGRE_PLUGIN_DIR_DBG=\"/lib64/OGRE\" -DOGRE_PLUGIN_DIR_REL=\"/lib64/OGRE\" -DSHARED_DATA_DIR=\"share/games/stuntrally\" -I/usr/include/OGRE -I/usr/include/OGRE/Terrain -I/usr/include/OGRE/Paging -I/usr/include/OGRE/Overlay -I/usr/include/bullet -I/usr/include/SDL2 -I/usr/include/MYGUI -I/usr/include/AL -I/home/iurt/rpmbuild/BUILD/stuntrally-2.6/source/btOgre -I/home/iurt/rpmbuild/BUILD/stuntrally-2.6/source/ogre -I/home/iurt/rpmbuild/BUILD/stuntrally-2.6/source/ogre/common -I/home/iurt/rpmbuild/BUILD/stuntrally-2.6/source/paged-geom -I/home/iurt/rpmbuild/BUILD/stuntrally-2.6/source/road -I/home/iurt/rpmbuild/BUILD/stuntrally-2.6/source/sound -I/home/iurt/rpmbuild/BUILD/stuntrally-2.6/source/vdrift  -O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4  -fPIC -DNDEBUG   -o CMakeFiles/stuntrally.dir/ogre/CHud.cpp.o -c /home/iurt/rpmbuild/BUILD/stuntrally-2.6/source/ogre/CHud.cpp
/home/iurt/rpmbuild/BUILD/stuntrally-2.6/source/ogre/CHud.cpp: In member function 'void CHud::bltDumpRecursive(CProfileIterator*, int, std::stringstream&)':
/home/iurt/rpmbuild/BUILD/stuntrally-2.6/source/ogre/CHud.cpp:160:5: error: invalid use of incomplete type 'class CProfileIterator'
  pit->First();
     ^
In file included from /home/iurt/rpmbuild/BUILD/stuntrally-2.6/source/ogre/CHud.cpp:4:0:
/home/iurt/rpmbuild/BUILD/stuntrally-2.6/source/ogre/CHud.h:158:30: note: forward declaration of 'class CProfileIterator'
  void bltDumpRecursive(class CProfileIterator* profileIterator, int spacing, std::stringstream& os);
                              ^
/home/iurt/rpmbuild/BUILD/stuntrally-2.6/source/ogre/CHud.cpp:161:9: error: invalid use of incomplete type 'class CProfileIterator'
  if (pit->Is_Done())
         ^
[... a dozen more related errors and notes]
```