### PR TITLE
Don't try to initialize haptic

### DIFF
--- a/source/ogre/BaseApp_Create.cpp
+++ b/source/ogre/BaseApp_Create.cpp
@@ -254,7 +254,7 @@ bool BaseApp::configure()
 
 	mRoot->initialise(false);
 
-	Uint32 flags = SDL_INIT_VIDEO|SDL_INIT_JOYSTICK|SDL_INIT_HAPTIC|SDL_INIT_NOPARACHUTE;
+	Uint32 flags = SDL_INIT_VIDEO|SDL_INIT_JOYSTICK|SDL_INIT_NOPARACHUTE;
 	if (SDL_WasInit(flags) == 0)
 	{
 		SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");


### PR DESCRIPTION
This make the game fail to start on FreeBSD, because SDL does not support haptic there. SDL_haptic doesn't seem to be used in the game anyway.