### PR TITLE
Fix narrowing conversion issue [-Wnarrowing]

### DIFF
--- a/source/editor/CApp.h
+++ b/source/editor/CApp.h
@@ -137,7 +137,8 @@ public:
 		float Size,Intens,Pow,Fq,NOf;
 		int Oct;  EBrShape shape;
 		float Filter,HSet;
-		char newLine;  Ogre::String name;
+		signed char newLine;
+		Ogre::String name;
 	};
 
 	const static int brSetsNum = 87;

--- a/source/editor/TerrainBrushes.cpp
+++ b/source/editor/TerrainBrushes.cpp
@@ -5,7 +5,7 @@
 //  Brush Presets data
 //---------------------------------------------------------------------------------------------------------------
 const App::BrushSet App::brSets[App::brSetsNum] = {
-//ED_MODE,curBr,  Size, Intens,  Pow, Freq,  Ofs, Oct, EBrShape, Filter, HSet,  Name
+	//ED_MODE,curBr,Size,Intens, Pow,  Freq,  Ofs, Oct, EBrShape,  Filter,HSet, newLine, Name
 //------  easy sinus
 	{ED_Deform,0,  16.f, 10.f,   2.f,  1.f,   0.f, 5,   BRS_Sinus,  -1.f,-0.01f, 0, "Small"},
 	{ED_Deform,0,  32.f, 20.f,   2.f,  1.f,   0.f, 5,   BRS_Sinus,  -1.f,-0.01f, 0, "Medium"},


### PR DESCRIPTION
Fixes the following issue on aarch64 with GCC 8.1:
source/editor/TerrainBrushes.cpp:138:1: error: narrowing conversion of '-1' from 'int' to 'char' inside { } [-Wnarrowing]

newLine is expected to take values -1, 0 or 1, so it can't be a char.