### PR TITLE
Fix invalid conversion errors for Ogre ExceptionCodes [-fpermissive]

### DIFF
--- a/source/paged-geom/BatchedGeometry.cpp
+++ b/source/paged-geom/BatchedGeometry.cpp
@@ -200,7 +200,7 @@ uint32 CountUsedVertices(IndexData *id, std::map<uint32, uint32> &ibmap)
          break;
 
       default:
-         throw new Ogre::Exception(0, "Unknown index buffer type", "Converter.cpp::CountVertices");
+         throw new Ogre::Exception(Exception::ERR_INVALIDPARAMS, "Unknown index buffer type", "Converter.cpp::CountVertices");
          break;
    }
 
@@ -545,7 +545,7 @@ void BatchedGeometry::SubBatch::addSubEntity(SubEntity *ent, const Vector3 &posi
       case VET_COLOUR_ABGR:
          break;
       default:
-         OGRE_EXCEPT(0, "Unknown RenderSystem color format", "BatchedGeometry::SubBatch::addSubMesh()");
+         OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, "Unknown RenderSystem color format", "BatchedGeometry::SubBatch::addSubMesh()");
          break;
       }
    }

--- a/source/paged-geom/PagedGeometry.cpp
+++ b/source/paged-geom/PagedGeometry.cpp
@@ -164,7 +164,7 @@ Vector3 PagedGeometry::_convertToLocal(const Vector3 &globalVec) const
 void PagedGeometry::setPageSize(Real size)
 {
 	if (!managerList.empty())
-		OGRE_EXCEPT(0, "PagedGeometry::setPageSize() cannot be called after detail levels have been added. Call removeDetailLevels() first.", "PagedGeometry::setPageSize()");
+		OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, "PagedGeometry::setPageSize() cannot be called after detail levels have been added. Call removeDetailLevels() first.", "PagedGeometry::setPageSize()");
 
 	pageSize = size;
 }
@@ -172,7 +172,7 @@ void PagedGeometry::setPageSize(Real size)
 void PagedGeometry::setInfinite()
 {
 	if (!managerList.empty())
-		OGRE_EXCEPT(0, "PagedGeometry::setInfinite() cannot be called after detail levels have been added. Call removeDetailLevels() first.", "PagedGeometry::setInfinite()");
+		OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, "PagedGeometry::setInfinite() cannot be called after detail levels have been added. Call removeDetailLevels() first.", "PagedGeometry::setInfinite()");
 
 	m_bounds = TBounds(0, 0, 0, 0);
 }
@@ -180,7 +180,7 @@ void PagedGeometry::setInfinite()
 void PagedGeometry::setBounds(TBounds bounds)
 {
 	if (!managerList.empty())
-		OGRE_EXCEPT(0, "PagedGeometry::setBounds() cannot be called after detail levels have been added. Call removeDetailLevels() first.", "PagedGeometry::setBounds()");
+		OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, "PagedGeometry::setBounds() cannot be called after detail levels have been added. Call removeDetailLevels() first.", "PagedGeometry::setBounds()");
 	if (!Math::RealEqual(bounds.width(), bounds.height(), 0.01f))
 		OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, "Bounds must be square", "PagedGeometry::setBounds()");
 	if (bounds.width() <= 0 || bounds.height() <=0)
@@ -364,7 +364,7 @@ void PagedGeometry::_addDetailLevel(GeometryPageManager *mgr, Real maxRange, Rea
 
 	//Error check
 	if (maxRange <= minRange){
-		OGRE_EXCEPT(1, "Closer detail levels must be added before farther ones", "PagedGeometry::addDetailLevel()");
+		OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, "Closer detail levels must be added before farther ones", "PagedGeometry::addDetailLevel()");
 	}
 
 	//Setup the new manager

--- a/source/paged-geom/PropertyMaps.cpp
+++ b/source/paged-geom/PropertyMaps.cpp
@@ -112,7 +112,7 @@ DensityMap::DensityMap(TexturePtr map, MapChannel channel)
 			case CHANNEL_GREEN: channelOffset = 2; break;
 			case CHANNEL_BLUE: channelOffset = 1; break;
 			case CHANNEL_ALPHA: channelOffset = 0; break;
-			default: OGRE_EXCEPT(0, "Invalid channel", "GrassLayer::setDensityMap()"); break;
+			default: OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, "Invalid channel", "GrassLayer::setDensityMap()"); break;
 		}
 
 		//And copy that channel into the density map
@@ -164,7 +164,7 @@ DensityMap::DensityMap(String map, MapChannel channel)
 				case CHANNEL_BLUE: colval = col.b; break;
 				case CHANNEL_ALPHA: colval = col.a; break;
 				case CHANNEL_COLOR: colval = col.r; break;
-				default: OGRE_EXCEPT(0, "Invalid channel", "GrassLayer::setDensityMap()"); break;
+				default: OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, "Invalid channel", "GrassLayer::setDensityMap()"); break;
 			}
 			outputPtr[j*width+i] = colval * 255.0f;
 
@@ -321,7 +321,7 @@ ColorMap::ColorMap(TexturePtr map, MapChannel channel)
 				channel = CHANNEL_RED;
 			break;
 		default:
-			OGRE_EXCEPT(0, "Unknown RenderSystem color format", "GrassLayer::setColorMap()");
+			OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, "Unknown RenderSystem color format", "GrassLayer::setColorMap()");
 			break;
 	}
 
@@ -344,7 +344,7 @@ ColorMap::ColorMap(TexturePtr map, MapChannel channel)
 			case CHANNEL_GREEN: channelOffset = 2; break;
 			case CHANNEL_BLUE: channelOffset = 1; break;
 			case CHANNEL_ALPHA: channelOffset = 0; break;
-			default: OGRE_EXCEPT(0, "Invalid channel", "ColorMap::ColorMap()"); break;
+			default: OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, "Invalid channel", "ColorMap::ColorMap()"); break;
 		}
 
 		//And copy that channel into the density map

--- a/source/paged-geom/TreeLoader2D.cpp
+++ b/source/paged-geom/TreeLoader2D.cpp
@@ -542,7 +542,7 @@ void TreeIterator2D::moveNext()
 {
 	//Out of bounds check
 	if (!hasMore)
-		OGRE_EXCEPT(1, "Cannot read past end of TreeIterator list", "TreeIterator::moveNext()");
+		OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, "Cannot read past end of TreeIterator list", "TreeIterator::moveNext()");
 
 	//Preserve the last tree
 	prevTreeDat = currentTreeDat;

--- a/source/paged-geom/TreeLoader3D.cpp
+++ b/source/paged-geom/TreeLoader3D.cpp
@@ -529,7 +529,7 @@ void TreeIterator3D::moveNext()
 {
 	//Out of bounds check
 	if (!hasMore)
-		OGRE_EXCEPT(1, "Cannot read past end of TreeIterator list", "TreeIterator::moveNext()");
+		OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, "Cannot read past end of TreeIterator list", "TreeIterator::moveNext()");
 
 	//Preserve the last tree
 	prevTreeDat = currentTreeDat;

--- a/source/sound/SoundMgr.cpp
+++ b/source/sound/SoundMgr.cpp
@@ -4,6 +4,7 @@
 #include "SoundBase.h"
 #include "SoundBaseMgr.h"
 #include <OgreDataStream.h>
+#include <OgreException.h>
 using namespace Ogre;
 
 


### PR DESCRIPTION
Fixes the following GCC 8 error:
error: invalid conversion from 'int' to 'Ogre::Exception::ExceptionCodes' [-fpermissive]

Used ERR_INVALIDPARAMS in some places where ERR_INVALID_CALL would be more
appropriate, because ERR_INVALID_CALL is new in Ogre 1.10+ and using it
would break Ogre 1.9 support.