### PR TITLE
Use `isnan` (from isnan.h) consistently

### DIFF
--- a/source/vdrift/cartire.cpp
+++ b/source/vdrift/cartire.cpp
@@ -280,7 +280,7 @@ Dbl CARTIRE::Pacejka_Fx (Dbl sigma, Dbl Fz, Dbl friction_coeff, Dbl & maxforce_o
 
 	maxforce_output = D;
 
-	assert(!std::isnan(Fx));
+	assert(!isnan(Fx));
 	return Fx;
 }
 


### PR DESCRIPTION
`std::isnan` can't be used as it expands to `std::std::isnan` due to `isnan`