### PR TITLE
Add missing include for <dirent.h> on POSIX

### DIFF
--- a/source/vdrift/pathmanager.cpp
+++ b/source/vdrift/pathmanager.cpp
@@ -13,6 +13,9 @@
 #ifdef _WIN32
 #include <windows.h>
 #include <shlobj.h>
+#else
+#include <sys/types.h>
+#include <dirent.h>
 #endif
 
 // Should come from CMake


### PR DESCRIPTION
It would fail building with GCC 11.2 and glibc 2.35.