### PR TITLE
Request dedicated GPU in the `.desktop` files

### DIFF
--- a/dist/sr-editor.desktop
+++ b/dist/sr-editor.desktop
@@ -13,6 +13,6 @@ Exec=sr-editor
 Icon=sr-editor
 StartupNotify=false
 Terminal=false
+PrefersNonDefaultGPU=true
 Type=Application
-Categories=Application;Game;SportsGame;
-
+Categories=Game;SportsGame;

--- a/dist/stuntrally.desktop
+++ b/dist/stuntrally.desktop
@@ -10,6 +10,6 @@ Exec=stuntrally
 Icon=stuntrally
 StartupNotify=false
 Terminal=false
+PrefersNonDefaultGPU=true
 Type=Application
-Categories=Application;Game;SportsGame;
-
+Categories=Game;SportsGame;


### PR DESCRIPTION
- Remove deprecated `Application` category as reported by desktop-file-validate.

This works on new and old systems alike. On old systems, the property will be ignored, so Stunt Rally will still be able to start.

desktop-file-validate still gives me one warning, which I don't know how to fix correctly as I don't speak German. Could any German speaker lend a hand here? Thanks in advance :slightly_smiling_face:

```
❯ desktop-file-validate dist/*.desktop
dist/sr-editor.desktop: warning: value "Stunt Rally Streckeneditor" for key "Comment[de]" in group "Desktop Entry" looks the same as that of key "Name[de]"
```

This closes https://github.com/stuntrally/stuntrally/issues/45.