### PR TITLE
Fix CMake warnings due to minimum version being too low

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(StuntRally CXX C)
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 # Allows disabling building of components
 option(BUILD_GAME             "Build the game binary."    ON)
@@ -162,4 +162,3 @@ add_subdirectory(source)
 add_subdirectory(config)
 add_subdirectory(dist)
 add_subdirectory(data)
-

--- a/cmake/FindMyGUI.cmake
+++ b/cmake/FindMyGUI.cmake
@@ -26,26 +26,26 @@ IF (WIN32) #Windows
 		STRING(REGEX REPLACE "[\\]" "/" MYGUISDK "${MYGUISDK}" )
 
 		find_path ( MYGUI_INCLUDE_DIRS
-		  MyGUI.h 
+		  MyGUI.h
 		  "${MYGUISDK}/MyGUIEngine/include"
 		  NO_DEFAULT_PATH )
-		  
+
 		find_path ( MYGUI_PLATFORM_INCLUDE_DIRS
 		  MyGUI_OgrePlatform.h
 		  "${MYGUISDK}/Platforms/Ogre/OgrePlatform/include"
-		  NO_DEFAULT_PATH )		  
+		  NO_DEFAULT_PATH )
 
 		SET ( MYGUI_LIB_DIR ${MYGUISDK}/*/lib )
-		
+
 		find_library ( MYGUI_LIBRARIES_REL NAMES
-		MyGUIEngine.lib 
+		MyGUIEngine.lib
 		MyGUI.OgrePlatform.lib
 		HINTS
 		${MYGUI_LIB_DIR}
 		PATH_SUFFIXES "" release relwithdebinfo minsizerel )
 
 		find_library ( MYGUI_LIBRARIES_DBG NAMES
-		MyGUIEngine_d.lib 
+		MyGUIEngine_d.lib
 		MyGUI.OgrePlatform_d.lib
 		HINTS
 		${MYGUI_LIB_DIR}
@@ -62,10 +62,10 @@ IF (WIN32) #Windows
 		HINTS
 		${MYGUI_LIB_DIR}
 		PATH_SUFFIXES "" debug )
-		
+
 		make_library_set ( MYGUI_LIBRARIES )
 		make_library_set ( MYGUI_PLATFORM_LIBRARIES )
-		
+
 		MESSAGE ("${MYGUI_LIBRARIES}")
 		MESSAGE ("${MYGUI_PLATFORM_LIBRARIES}")
 
@@ -80,7 +80,7 @@ IF (WIN32) #Windows
         SET(MYGUI_LIBRARIES debug Debug/MyGUIEngine_d optimized Release/MyGUIEngine)
     ENDIF (OGRESOURCE)
 ELSE (WIN32) #Unix
-    CMAKE_MINIMUM_REQUIRED(VERSION 2.4.7 FATAL_ERROR)
+    CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
     FIND_PACKAGE(PkgConfig)
     PKG_SEARCH_MODULE(MYGUI MYGUI MyGUI)
     IF (MYGUI_INCLUDE_DIRS)

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 # Install data files
 # TODO: make this use all data/* subdirs without tracks, not entered by hand ..
@@ -12,4 +12,3 @@ if (EXISTS "${CMAKE_SOURCE_DIR}/data/tracks")
 else()
 	message("WARNING: No tracks could be found for installation.")
 endif()
-

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 # Linux prefers lower-case exe names
 if (WIN32 OR APPLE)
@@ -170,4 +170,3 @@ if (MSVC)
 		COMPILE_FLAGS "/Ycpch.h"
 	)
 endif (MSVC)
-

--- a/source/btOgre/CMakeLists.txt
+++ b/source/btOgre/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 set(LIBNAME "btOgre")
 
@@ -9,4 +9,3 @@ file(GLOB SOURCE_FILES *.cpp)
 add_library(${LIBNAME} STATIC ${SOURCE_FILES})
 
 link_directories(${CMAKE_CURRENT_BINARY_DIR})
-

--- a/source/paged-geom/CMakeLists.txt
+++ b/source/paged-geom/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 set(LIBNAME "paged-geom")
 
@@ -9,4 +9,3 @@ file(GLOB SOURCE_FILES *.cpp)
 add_library(${LIBNAME} STATIC ${SOURCE_FILES})
 
 link_directories(${CMAKE_CURRENT_BINARY_DIR})
-

--- a/source/shiny/CMakeLists.txt
+++ b/source/shiny/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 set(SHINY_MAJOR_VERSION 0)
 set(SHINY_MINOR_VERSION 3)

--- a/source/tinyxml/CMakeLists.txt
+++ b/source/tinyxml/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 set(LIBNAME "tinyxml")
 
@@ -9,4 +9,3 @@ file(GLOB SOURCE_FILES *.cpp)
 add_library(${LIBNAME} STATIC ${SOURCE_FILES})
 
 link_directories(${CMAKE_CURRENT_BINARY_DIR})
-


### PR DESCRIPTION
`stuntrally` counterpart of https://github.com/Calinou/stuntrally (should be merged at the same time).

CMake 3.22.2 warns about CMake versions prior to 2.8.12 no longer being supported soon. Increasing the minimum version requirement fixes those warnings.

2.8.12 is a very old version by now, and even Debian oldoldstable (stretch) has a more recent version (3.7.2, 3.16.3 in backports).