### PR TITLE
Default building to release mode with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,8 @@ endif(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
 
 # Add a sensible build type default and warning because empty means no optimization and no debug info.
 if(NOT CMAKE_BUILD_TYPE)
-	message("WARNING: CMAKE_BUILD_TYPE is not defined!\n         Defaulting to CMAKE_BUILD_TYPE=RelWithDebInfo. Use ccmake to set a proper value.")
-	set(CMAKE_BUILD_TYPE RelWithDebInfo
+	message("WARNING: CMAKE_BUILD_TYPE is not defined!\n         Defaulting to CMAKE_BUILD_TYPE=Release. Use ccmake to set a proper value.")
+	set(CMAKE_BUILD_TYPE Release
 	CACHE STRING "Type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
 


### PR DESCRIPTION
CMake's Release build type provides better optimization (`-O3`) compared to RelWithDebInfo (`-O2 -g`). This results in less CPU overhead while playing, potentially leading to higher FPS and lower power consumption.

This is especially important for casual users who are just cloning the source code to build and play, as they may not realize that they're not using the maximum optimization level.

The downside is that crash backtraces will no longer be accurate by default, so developers should remember to change the target using `cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo`.