### PR TITLE
Fix formatting in VS Code file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -82,7 +82,7 @@
         //"bin-*/": true,
     },
     "workbench.colorCustomizations": {
-        "errorLens.errorForeground":"#F0A0F0"
+        "errorLens.errorForeground": "#F0A0F0"
     },
     "C_Cpp.autocomplete": "Disabled",
     "C_Cpp.formatting": "Disabled",
@@ -92,7 +92,7 @@
       "-clang-tidy-checks=-*,modernize-use-override",
       "--suggest-missing-includes",
       "--header-insertion=iwyu"
-    ],    
+    ],
     "favorites.sortDirection": "ASC",
     "python.pythonPath": "/usr/bin/python3",
     "editor.suggest.localityBonus": true,


### PR DESCRIPTION
VS Code 1.64.0 automatically performs those changes when opening the editor. Committing these changes prevents spurious "modified file" notices in Git.