### PR TITLE
Remove reference to removed S1 car in S8 car description

### DIFF
--- a/data/gui/core_language_en_tag.xml
+++ b/data/gui/core_language_en_tag.xml
@@ -1499,7 +1499,7 @@
 	<Tag name="CarDesc_ES">Best rally car in game, great driving experience on all tracks. A bit high though.</Tag>
 	<Tag name="CarDesc_FN">Another good rally car, suited for all tracks. Is not that long and thus easier to steer.</Tag>
 	<Tag name="CarDesc_HI">Best rally car in game, drivable on all tracks with the best experience, similar to ES.</Tag>
-	<Tag name="CarDesc_S8">Good rally car, drivable on all tracks. Similar to S1, but shorter and more steerable.</Tag>
+	<Tag name="CarDesc_S8">Good rally car, drivable on all tracks.</Tag>
 
 	<Tag name="CarDesc_OT">This is the slowest car. Very old and a bit creepy truck. Can drive only on flat tracks and with turtle speed.</Tag>
 	<Tag name="CarDesc_TW">This big, extreme vehicle is great for long and smooth tracks. But completely useless when narrow or in mud (e.g. in jungle). Also not easy to drive.</Tag>


### PR DESCRIPTION
PS: it might be worth considering using the animal names in other car descriptions (such as HI's description).