### PR TITLE
Improve FOV boost defaults and configureation

### DIFF
--- a/config/game-default.cfg
+++ b/config/game-default.cfg
@@ -127,7 +127,7 @@ water_rttsize = 0
 count = 2
 dist = 1300.000000
 lightmap_size = 0
-shader_mode = 
+shader_mode =
 size = 3
 type = 1
 
@@ -201,7 +201,7 @@ cam_bounce = on
 cam_in_loop = 1
 cam_loop_chng = on
 fov = 90.000000
-fov_max = 120.000000
+fov_boost = 5.000000
 fov_smooth = 5.000000
 gauges = 0.190000
 gauges_type = 3
@@ -221,7 +221,7 @@ bulletProfilerTxt = off
 dev_keys = off
 dev_no_prvs = off
 escquit = off
-language = 
+language =
 loadingback = on
 mouse_capture = on
 ogredialog = off
@@ -233,7 +233,7 @@ show_welcome = on
 [ network ]
 game_name = Default Game
 local_port = 4243
-master_server_address = 
+master_server_address =
 master_server_port = 4243
 nickname = Player
 
@@ -271,7 +271,7 @@ perf_speed = 100000.000000
 thread_sleep = 5
 
 [ sound ]
-device = 
+device =
 hud_chk = off
 hud_chk_wrong = on
 hud_vol = 0.750000

--- a/data/gui/Game_Options.layout
+++ b/data/gui/Game_Options.layout
@@ -614,24 +614,19 @@
 							<Property key="Colour" value="0.7 0.9 0.9"/>
 						</Widget>
 
-						<Widget type="Button" skin="CheckBox" position="32 340 300 24" name="BoostFOV">
-							<Property key="Caption" value="#{BoostFOV} (#{Boost})"/>
-							<Property key="TextColour" value="0.6 0.95 0.95"/>
-						</Widget>
-
 						<Widget type="TextBox" skin="TextBox" position="32 380 260 22">
-							<Property key="Caption" value="#{FOV} #{max}"/>
+							<Property key="Caption" value="#{FOV} #{Boost}"/>
 							<Property key="TextColour" value="0.5 0.8 0.8"/>
 						</Widget>
-						<Widget type="TextBox" skin="TextBox" position="296 380 48 22" name="FovMaxVal">
+						<Widget type="TextBox" skin="TextBox" position="296 380 48 22" name="FovBoostVal">
 							<Property key="TextColour" value="0.5 0.8 0.8"/>
 						</Widget>
-						<Widget type="Slider" skin="Slider" position="344 380 320 16" name="FovMax">
+						<Widget type="Slider" skin="Slider" position="344 380 320 16" name="FovBoost">
 							<Property key="Colour" value="0.65 0.9 0.9"/>
 						</Widget>
 
 						<Widget type="TextBox" skin="TextBox" position="32 416 260 20">
-							<Property key="Caption" value="#{FOV} #{smooth}"/>
+							<Property key="Caption" value="#{FOV} #{Boost} #{smooth}"/>
 							<Property key="TextColour" value="0.5 0.7 0.7"/>
 						</Widget>
 						<Widget type="TextBox" skin="TextBox" position="296 416 48 20" name="FovSmVal">
@@ -1346,7 +1341,7 @@
 						</Widget>
 					</Widget>
 				</Widget>
-			</Widget>			
+			</Widget>
 			<Widget type="TabItem" skin="" position="2 24 794 562">
 				<Property key="Caption" value="#60A0FF#{Settings}"/>
 				<Widget type="TextBox" skin="TextBox" position="32 32 252 24">

--- a/source/ogre/CGui.h
+++ b/source/ogre/CGui.h
@@ -38,11 +38,11 @@ public:
 	App* app =0;  GAME* pGame =0;  SETTINGS* pSet =0;
 	Scene* sc =0;  CData* data =0;
 	CHud* hud =0;  MyGUI::Gui* mGui =0;  CGuiCom* gcom =0;
-	
+
 	CGui(App* ap1);
 	~CGui();
 	//friend class CarModel;
-	
+
 	typedef std::list <std::string> strlist;
 
 
@@ -68,7 +68,7 @@ public:
 	void AddCarL(std::string name, const CarInfo* ci);
 	std::list<CarL> liCar;
 	void FillCarList();
-	
+
 	const static int colCar[16],colCh[16],colChL[16],colSt[16];
 
 
@@ -76,7 +76,7 @@ public:
 	void toggleGui(bool toggle=true);
 	void GuiShortcut(EMenu menu, int tab, int subtab=-1);
 	bool loadReadme = 1;  void FillHelpTxt();
-	
+
 
 	//  hints
 	Ck ckShowWelcome;
@@ -88,7 +88,7 @@ public:
 	void btnHintPrev(WP), btnHintNext(WP);
 	void btnHintScreen(WP), btnHintInput(WP), btnHintClose(WP);
 	void btnHowToBack(WP), btnLesson(WP);
-	
+
 	struct Subtitle  // for replay lessons
 	{
 		std::string txt;
@@ -172,7 +172,7 @@ public:
 	void listTwkTiresUser(Li, size_t), listTwkTiresOrig(Li, size_t);
 	void btnTweakTireLoad(WP), btnTweakTireReset(WP), btnTweakTireDelete(WP);
 	void FillTweakLists();  Ogre::String sTireLoad;
-	
+
 	///  surface
 	Li liTwkSurfaces =0;  void listTwkSurfaces(Li, size_t);
 	int idTwkSurf = -1;  void btnTwkSurfPick(WP), updSld_TwkSurf(int id);
@@ -207,7 +207,7 @@ public:
 	//  hud view
 	SV svSizeGaug;
 	SV svTypeGaug, svLayoutGaug;
-	
+
 	SV svSizeMinimap, svZoomMinimap;
 	void slHudSize(SV*), slHudCreate(SV*);
 
@@ -220,8 +220,8 @@ public:
 	SV svVolEngine, svVolTires, svVolSusp, svVolEnv;
 	SV svVolFlSplash, svVolFlCont, svVolCarCrash, svVolCarScrap;
 	Ck ckSndChk, ckSndChkWr, ckReverb;
-	
-	
+
+
 	///  Checks  . . . . . . . . . . . . . . . . . . . .
 	CK(Reverse);  // track
 
@@ -238,7 +238,7 @@ public:
 	//  Camera
 	Ck ckCamInfo, ckCamTilt, ckCamLoop;
 	Ck ckCamBnc;  SV svCamBnc;
-	SV svFov, svFovMax, svFovSm;
+	SV svFov, svFovBoost, svFovSm;
 	//  Pacenotes
 	Ck ckPaceShow;  SV svPaceDist, svPaceSize, svPaceNext;
 	SV svPaceNear, svPaceAlpha;
@@ -252,7 +252,7 @@ public:
 	SV svTC_r, svTC_xr;
 	SV svTE_yf, svTE_xfx, svTE_xfy, svTE_xpow;
 	Ck ckTE_Common, ckTE_Reference;  void chkTEupd(Ck*);
-	
+
 	//  Hud dbg,other
 	Ck ckFps;  CK(Wireframe);
 	//  profiler
@@ -268,10 +268,9 @@ public:
 	Ck ckBltLines, ckShowPics;
 	Ck ckMouseCapture, ckDevKeys, ckScreenPng;
 	void chkMultiThread(WP);
-	
+
 	//  [Effects]
 	CK(AllEffects);
-	Ck ckBoostFOV;
 	Ck ckBloom, ckBlur, ckSoftPar, ckSSAO, ckGodRays, ckDoF, ckHDR;
 	void chkEffUpd(Ck*), chkEffUpdShd(Ck*);
 
@@ -291,7 +290,7 @@ public:
 	wraps::RenderBoxScene* viewBox =0;  Ogre::Vector3 viewSc;
 	MyGUI::IntCoord GetViewSize();
 	void InitCarPrv();
-	
+
 	WP graphV =0, graphS =0;
 	MyGUI::PolygonalSkin* graphVel =0,*graphVGrid =0, *graphSSS =0,*graphSGrid =0;
 
@@ -320,7 +319,7 @@ public:
 	void btnSSSReset(WP), btnSteerReset(WP), slSSS(SV*);
 
 	void imgBtnCarClr(WP), btnCarClrRandom(WP);  Img imgCarClr =0;
-	
+
 	//  radios
 	Btn bRkmh =0, bRmph =0;  // km/h, mph
 	void radKmh(WP), radMph(WP), radUpd(bool kmh);
@@ -345,7 +344,7 @@ public:
 	//  cur rpl stats gui
 	Txt valRplName =0, valRplInfo =0,
 		valRplName2 =0,valRplInfo2 =0;
-	
+
 	//  controls percent and time info
 	Txt valRplPerc =0, valRplCur =0, valRplLen =0;
 
@@ -355,7 +354,7 @@ public:
 	void btnRplLoad(WP), btnRplSave(WP), btnRplLoadFile(std::string file);
 	void btnRplDelete(WP), btnRplRename(WP);
 	bool bLesson =0;
-	
+
 	//  chk, options
 	Ck ckRplAutoRec, ckRplBestOnly, ckRplGhost, ckRplParticles;
 	Ck ckRplRewind, ckRplGhostOther, ckRplTrackGhost;
@@ -375,7 +374,7 @@ public:
 	void btnRplBackDn(WP,int,int,MyGUI::MouseButton), btnRplBackUp(WP,int,int,MyGUI::MouseButton);
 	void btnRplFwdDn(WP,int,int, MyGUI::MouseButton), btnRplFwdUp(WP,int,int, MyGUI::MouseButton);
 	void msgRplDelete(MyGUI::Message*, MyGUI::MessageBoxStyle);
-	
+
 
 	//  Game
 	///---------------------------------------
@@ -430,21 +429,21 @@ public:
 	Img imgTut =0, imgChamp =0, imgChall =0;
 	//  tabs
 	Tab tabTut =0, tabChamp =0, tabChall =0;
-	
+
 	void tabTutType(Tab, size_t), tabChampType(Tab, size_t);
 	void tabChallType(Tab, size_t);
 
 	//  stages
 	Ed edChInfo =0, edChDesc =0;  WP panCh =0;
 	Txt txtCh =0, valCh =0, txtChP[3] ={0,0,0}, valChP[3] ={0,0,0};  // stages info, pass/progress
-	
+
 	void btnStageNext(WP), btnStagePrev(WP);  Txt valStageNum =0;
 	void StageListAdd(int n, Ogre::String name, int laps, Ogre::String progress);
-	
+
 	//  xml  [1]= reversed  L= challenge
 	ProgressXml progress[2];
 	ProgressLXml progressL[2];
-	
+
 	void ProgressSave(bool upgGui=true), ProgressLSave(bool upgGui=true);
 	Chall* pChall =0;  // current challenge or 0 if not
 
@@ -454,7 +453,7 @@ public:
 	//  const
 	const static Ogre::String StrPrize(int i/*0 none..3 gold*/), strPrize[4],clrPrize[4];
 	const static int ciAddPos[3];  const static float cfSubPoints[3];
-	
+
 	//  common
 	Mli2 liStages =0, liNetEnd =0;  void listStageChng(Mli2, size_t);
 	Mli2 liChamps =0;  void listChampChng(Mli2, size_t);

--- a/source/ogre/Gui_Init.cpp
+++ b/source/ogre/Gui_Init.cpp
@@ -72,7 +72,7 @@ void CGui::InitGui()
 	app->mWndNetEnd = fWnd("WndNetEnd");  app->mWndNetEnd->setVisible(false);
 	app->mWndTweak = fWnd("WndTweak");    app->mWndTweak->setVisible(false);
 	app->mWndTweak->setPosition(0,40);
-	
+
 
 	//  for find defines
 	Btn btn, bchk;  Cmb cmb;
@@ -103,7 +103,7 @@ void CGui::InitGui()
 	if (pSet->iMenu >= MN_Tutorial && pSet->iMenu <= MN_Chall)
 		app->mWndTabsGame->setIndexSelected(TAB_Champs);
 
-	
+
 	//  replay
 	app->mWndRpl = fWnd("RplControlsWnd");
 	app->mWndRplTxt = fWnd("RplLessonTextWnd");
@@ -145,7 +145,7 @@ void CGui::InitGui()
 
 	///  Sliders
 	//------------------------------------------------------------------------
-	    
+
 	//  Hud view sizes  ----
 	sv= &svSizeGaug;	sv->Init("SizeGaug",	&pSet->size_gauges,    0.1f, 0.3f,  1.f, 3,4);  sv->DefaultF(0.19f);  Sev(HudSize);
 	sv= &svTypeGaug;	sv->Init("TypeGaug",	&pSet->gauges_type,    0, 5);  sv->DefaultI(5);  Sev(HudCreate);
@@ -271,20 +271,20 @@ void CGui::InitGui()
 	sv= &svCamBnc;		sv->Init("CamBnc",		&pSet->cam_bnc_mul, 0.f, 2.f);
 
 	sv= &svFov;			sv->Init("Fov",			&pSet->fov_min,   50.f, 180.f, 1.f, 1,4);  sv->DefaultF(90.f);
-	sv= &svFovMax;		sv->Init("FovMax",		&pSet->fov_max,   50.f, 180.f, 1.f, 1,4);  sv->DefaultF(120.f);
+	sv= &svFovBoost;	sv->Init("FovBoost",	&pSet->fov_boost,  0.f, 15.f, 1.f, 1,4);  sv->DefaultF(5.f);
 	sv= &svFovSm;		sv->Init("FovSm",		&pSet->fov_smooth, 0.f, 15.f, 1.5f);  sv->DefaultF(5.f);
-	
+
 	//  pacenotes
 	ck= &ckPaceShow;	ck->Init("ChkPace",		&pSet->pace_show);
 	sv= &svPaceNext;	sv->Init("PaceNext",	&pSet->pace_next,   2,8);  sv->DefaultI(4);
 	sv= &svPaceDist;	sv->Init("PaceDist",	&pSet->pace_dist,   20.f,1000.f, 2.f, 0,3);  sv->DefaultF(200.f);
-	
+
 	sv= &svPaceSize;	sv->Init("PaceSize",	&pSet->pace_size,   0.1f,2.f);  sv->DefaultF(1.f);  Sev(Upd_Pace);
 	sv= &svPaceNear;	sv->Init("PaceNear",	&pSet->pace_near,   0.1f,2.f);  sv->DefaultF(1.f);  Sev(Upd_Pace);
 	sv= &svPaceAlpha;	sv->Init("PaceAlpha",	&pSet->pace_alpha,  0.3f,1.f);  sv->DefaultF(1.f);  Sev(Upd_Pace);
 	//slUpd_Pace(0);
 	ck= &ckTrailShow;	ck->Init("ChkTrail",	&pSet->trail_show);  Cev(TrailShow);
-	
+
 
 	//  times, opp
 	ck= &ckTimes;		ck->Init("Times",       &pSet->show_times);      Cev(HudShow);
@@ -405,7 +405,6 @@ void CGui::InitGui()
 
 	//  effects
 	ck= &ckAllEffects;	ck->Init("AllEffects",	&pSet->all_effects);  Cev(AllEffects);
-	ck= &ckBoostFOV;	ck->Init("BoostFOV",	&pSet->boost_fov);
 
 	ck= &ckBloom;		ck->Init("Bloom",		&pSet->bloom);  Cev(EffUpd);
 	sv= &svBloomInt;	sv->Init("BloomInt",	&pSet->bloom_int);   sv->DefaultF(0.13f);  Sev(EffUpd);
@@ -512,7 +511,7 @@ void CGui::InitGui()
 	for (i=0; i < iCarSt; ++i)
 	{	txCarStTxt[i] = fTxt("cst"+toStr(i));
 		txCarStVals[i] = fTxt("csv"+toStr(i));
-		barCarSt[i] = fImg("cb"+toStr(i));  
+		barCarSt[i] = fImg("cb"+toStr(i));
 	}
 	txCarSpeed = fTxt("CarSpeed");  txCarType = fTxt("CarType");  txCarYear = fTxt("CarYear");
 	txCarRating = fTxt("CarRating");  txCarDiff = fTxt("CarDiff");  txCarWidth = fTxt("CarWidth");
@@ -613,7 +612,7 @@ void CGui::InitGui()
 		edCar[i] = fEd("EdCar"+toStr(i));
 	edPerfTest = fEd("TweakPerfTest");
 	tabEdCar = fTab("TabEdCar");  Tev(tabEdCar, CarEdChng);  tabEdCar->setIndexSelected(pSet->car_ed_tab);
-	
+
 	tabTweak = fTab("TabTweak");  Tev(tabTweak, TweakChng);  tabTweak->setIndexSelected(pSet->tweak_tab);
 	txtTweakPath = fTxt("TweakPath");
 	Btn("TweakCarSave", btnTweakCarSave);

--- a/source/ogre/SplitScreen.cpp
+++ b/source/ogre/SplitScreen.cpp
@@ -63,7 +63,7 @@ void SplitScr::CleanUp()
 		mWindow->removeViewport( (*vpIt)->getZOrder() );
 	}
 	mViewports.clear();
-	
+
 	for (std::list<Camera*>::iterator it=mCameras.begin(); it != mCameras.end(); ++it)
 		mSceneMgr->destroyCamera(*it);
 	mCameras.clear();
@@ -76,7 +76,7 @@ void SplitScr::Align()
 {
 	CleanUp();
 	LogO("-- Screen Align");
-	
+
 	for (int i=0; i < 4; ++i)
 		mDims[i].Default();
 
@@ -86,7 +86,7 @@ void SplitScr::Align()
 		//  set dimensions for the viewports
 		float dims[4];  // left,top, width,height
 		#define dim_(l,t,w,h)  {  dims[0]=l;  dims[1]=t;  dims[2]=w;  dims[3]=h;  }
-		
+
 		if (mNumViewports == 1)
 		{
 			dim_(0.0, 0.0, 1.0, 1.0);
@@ -142,7 +142,7 @@ void SplitScr::Align()
 		mCameras.back()->lookAt(Vector3(0,-100,10));
 		mCameras.back()->setFarClipDistance(pSet->view_distance*1.1f);
 		mCameras.back()->setNearClipDistance(0.2f);
-		
+
 		// Create viewport, use i as Z order
 		mViewports.push_back(mWindow->addViewport( mCameras.back(), i+5, dims[0], dims[1], dims[2], dims[3]));
 	}
@@ -155,7 +155,7 @@ void SplitScr::Align()
 		mCameras.back()->setFarClipDistance(pSet->view_distance*1.1f);
 		mCameras.back()->setNearClipDistance(0.2f);
 	}
-		
+
 	// Create gui viewport if not already existing
 	if (!mGuiViewport)
 	{
@@ -164,9 +164,9 @@ void SplitScr::Align()
 		mGuiViewport = mWindow->addViewport(guiCam, 100);
 		mGuiViewport->setVisibilityMask(RV_Hud);
 	}
-	
+
 	AdjustRatio();
-	
+
 	// Add compositing filters for the new viewports
 	if (pApp)  pApp->recreateCompositor();
 }
@@ -193,7 +193,7 @@ void SplitScr::preViewportUpdate(const RenderTargetViewportEvent& evt)
 	//  What kind of viewport is being updated?
 	const String& vpName = evt.source->getCamera()->getName();
 	//*H*/LogO(vpName);  //GuiCam1  PlayerCamera0,1..
-	
+
 	if (evt.source != mGuiViewport)
 	{
 		//  scene viewport
@@ -209,7 +209,7 @@ void SplitScr::preViewportUpdate(const RenderTargetViewportEvent& evt)
 		//  idea: with compositor this needs separate sky nodes (own sky for each player) and showing 1 sky for 1 player
 		if (pApp->ndSky)
 			pApp->ndSky->setPosition(evt.source->getCamera()->getPosition());
-			
+
 
 		//  road lod for each viewport
 		if (mNumViewports > 1)
@@ -218,7 +218,7 @@ void SplitScr::preViewportUpdate(const RenderTargetViewportEvent& evt)
 			pApp->scn->road->mCamera = evt.source->getCamera();
 			pApp->scn->road->UpdLodVis(pSet->road_dist);
 		}
-		
+
 		//  Update rain/snow - depends on camera
 		//  todo: every player/viewport needs own weather particles  pr[carId]
 		if (pSet->particles)
@@ -236,18 +236,14 @@ void SplitScr::preViewportUpdate(const RenderTargetViewportEvent& evt)
 					if (c->ndNextChk)
 						c->ndNextChk->setVisible(i==carId);
 			}	}
-				
+
 			//  change FOV when boosting
-			if (pApp->pSet->boost_fov)
+			CAR* pCar = cm->pCar;
+			if (pCar)
 			{
-				CAR* pCar = cm->pCar;
-				if (pCar)
-				{
-					float fov = pSet->fov_min + (pSet->fov_max - pSet->fov_min) * pCar->dynamics.fBoostFov;
-					evt.source->getCamera()->setFOVy(Degree(0.5f*fov));
-				}
-			}else
-				evt.source->getCamera()->setFOVy(Degree(0.5f*pSet->fov_min));
+				float fov = pSet->fov_min + pSet->fov_boost * pCar->dynamics.fBoostFov;
+				evt.source->getCamera()->setFOVy(Degree(0.5f*fov));
+			}
 		}
 
 		//  update soft particle Depth Target
@@ -265,7 +261,7 @@ void SplitScr::preViewportUpdate(const RenderTargetViewportEvent& evt)
 	{	//  Gui viewport - hide stuff we don't want
 		pApp->hud->Update(-1, 1.f / mWindow->getStatistics().lastFPS);
 		pApp->hud->ShowVp(false);
-		
+
 		// no mouse in key capture mode
 		//if (pApp->bAssignKey)  hideMouse();
 	}

--- a/source/ogre/settings.cpp
+++ b/source/ogre/settings.cpp
@@ -20,9 +20,9 @@ void SETTINGS::Save(std::string sfile)
 void SETTINGS::Serialize(bool w, CONFIGFILE & c)
 {
 	c.bFltFull = false;
-	
+
 	SerializeCommon(w,c);
-	
+
 	Param(c,w, "game.menu", iMenu);  Param(c,w, "game.ymain", yMain);  Param(c,w, "game.yrace", yRace);
 	Param(c,w, "game.difficulty", difficulty);
 
@@ -65,21 +65,21 @@ void SETTINGS::Serialize(bool w, CONFIGFILE & c)
 	Param(c,w, "game.boost_power", gui.boost_power);
 	Param(c,w, "game.boost_min", gui.boost_min);		Param(c,w, "game.boost_max", gui.boost_max);
 	Param(c,w, "game.boost_per_km", gui.boost_per_km);	Param(c,w, "game.boost_add_sec", gui.boost_add_sec);
-	
+
 	Param(c,w, "game.collis_cars", gui.collis_cars);	Param(c,w, "game.collis_veget", gui.collis_veget);
 	Param(c,w, "game.collis_roadw", gui.collis_roadw);	Param(c,w, "game.dyn_objects", gui.dyn_objects);
-	
+
 	Param(c,w, "game.trk_reverse", gui.trackreverse);	Param(c,w, "game.sim_mode", gui.sim_mode);
 	Param(c,w, "game.local_players", gui.local_players); Param(c,w, "game.num_laps", gui.num_laps);
 	Param(c,w, "game.start_order", gui.start_order);	Param(c,w, "game.split_vertically", split_vertically);
-	
+
 	//  graphs
 	Param(c,w, "graphs.tc_r", tc_r);			Param(c,w, "graphs.tc_xr", tc_xr);
 	Param(c,w, "graphs.te_yf", te_yf);			Param(c,w, "graphs.te_xf_pow", te_xf_pow);
 	Param(c,w, "graphs.te_xfx", te_xfx);		Param(c,w, "graphs.te_xfy", te_xfy);
 	Param(c,w, "graphs.te_reference", te_reference);	Param(c,w, "graphs.te_common", te_common);
 
-	
+
 	//  hud
 	Param(c,w, "hud_show.mph", show_mph);
 	Param(c,w, "hud_show.gauges", show_gauges);			Param(c,w, "hud_show.show_digits", show_digits);
@@ -105,7 +105,7 @@ void SETTINGS::Serialize(bool w, CONFIGFILE & c)
 	Param(c,w, "hud_size.gauges_type", gauges_type);	//Param(c,w, "hud_size.gauges_layout", gauges_layout);
 	//  cam
 	Param(c,w, "hud_size.cam_loop_chng", cam_loop_chng); Param(c,w, "hud_size.cam_in_loop", cam_in_loop);
-	Param(c,w, "hud_size.fov", fov_min);				Param(c,w, "hud_size.fov_max", fov_max);
+	Param(c,w, "hud_size.fov", fov_min);				Param(c,w, "hud_size.fov_boost", fov_boost);
 	Param(c,w, "hud_size.fov_smooth", fov_smooth);
 	Param(c,w, "hud_size.cam_bounce", cam_bounce);		Param(c,w, "hud_size.cam_bnc_mul", cam_bnc_mul);
 	//  pacenotes
@@ -113,7 +113,7 @@ void SETTINGS::Serialize(bool w, CONFIGFILE & c)
 	Param(c,w, "pacenotes.size", pace_size);		Param(c,w, "pacenotes.near", pace_near);
 	Param(c,w, "pacenotes.next", pace_next);		Param(c,w, "pacenotes.alpha", pace_alpha);
 	Param(c,w, "pacenotes.trail", trail_show);
-	
+
 
 	//  graphics
 	Param(c,w, "graph_par.particles", particles);			Param(c,w, "graph_par.trails", trails);
@@ -144,14 +144,14 @@ void SETTINGS::Serialize(bool w, CONFIGFILE & c)
 	Param(c,w, "replay.ghostpar", rpl_ghostpar);	Param(c,w, "replay.ghostother", rpl_ghostother);
 	Param(c,w, "replay.num_views", rpl_numViews);	Param(c,w, "replay.ghostrewind", rpl_ghostrewind);
 	Param(c,w, "replay.ghoHideDist", ghoHideDist);	Param(c,w, "replay.ghoHideDistTrk", ghoHideDistTrk);
-	
+
 	//  sim
 	Param(c,w, "sim.game_freq", game_fq);			Param(c,w, "sim.multi_thr", multi_thr);
 	Param(c,w, "sim.bullet_freq", blt_fq);			Param(c,w, "sim.bullet_iter", blt_iter);
 	Param(c,w, "sim.dynamics_iter", dyn_iter);		Param(c,w, "sim.thread_sleep", thread_sleep);
 	Param(c,w, "sim.perf_speed", perf_speed);		Param(c,w, "sim.gui_sleep", gui_sleep);
 
-	
+
 	//  sound
 	Param(c,w, "sound.device", snd_device);			Param(c,w, "sound.reverb", snd_reverb);
 	Param(c,w, "sound.volume", vol_master);			Param(c,w, "sound.vol_engine", vol_engine);
@@ -165,7 +165,7 @@ void SETTINGS::Serialize(bool w, CONFIGFILE & c)
 	//  effects
 	Param(c,w, "video_eff.all_effects", all_effects);
 	Param(c,w, "video_eff.bloom", bloom);				Param(c,w, "video_eff.bloomintensity", bloom_int);
-	Param(c,w, "video_eff.bloomorig", bloom_orig);		
+	Param(c,w, "video_eff.bloomorig", bloom_orig);
 	Param(c,w, "video_eff.motionblur", blur);			Param(c,w, "video_eff.motionblurintensity", blur_int);
 	Param(c,w, "video_eff.ssao", ssao);					Param(c,w, "video_eff.softparticles", softparticles);
 	Param(c,w, "video_eff.godrays", godrays);
@@ -188,20 +188,20 @@ SETTINGS::SETTINGS()   ///  Defaults
 	,show_opponents(1), opplist_sort(true), cam_tilt(1)
 	,car_dbgtxt(0), car_dbgbars(0), car_dbgsurf(0), show_graphs(0)
 	,car_dbgtxtclr(0), car_dbgtxtcnt(0), car_tirevis(0), sounds_info(0)
-	
+
 	,size_gauges(0.18), size_minimap(0.2), size_minipos(0.1), zoom_minimap(1.0)
 	,mini_zoomed(0), mini_rotated(1), mini_terrain(0), mini_border(1)
 	,check_arrow(0),size_arrow(0.2), check_beam(1)
 	,gauges_type(1),gauges_layout(1), graphs_type(Gh_Fps)
 	//  cam
 	,cam_loop_chng(1), cam_in_loop(1)
-	,fov_min(90.f), fov_max(120.f), fov_smooth(5.f)
+	,fov_min(90.f), fov_boost(5.f), fov_smooth(5.f)
 	,cam_bounce(1), cam_bnc_mul(1.f)
 	//  pace
 	,pace_show(1), pace_next(4)
 	,pace_dist(200.f), pace_size(1.f), pace_near(1.f), pace_alpha(1.f)
 	,trail_show(1)
-	
+
 	//  gui
 	,cars_view(0), cars_sort(1), cars_sortup(1)
 	,champ_type(0),tut_type(0),chall_type(0), champ_info(1)
@@ -284,7 +284,7 @@ SETTINGS::GameSet::GameSet()
 	,rpl_rec(1)
 	//  champ
 	,champ_num(-1), chall_num(-1)
-	,champ_rev(false)	
+	,champ_rev(false)
 	,pre_time(2.f), start_order(0)
 {
 	car_hue.resize(6);  car_sat.resize(6);  car_val.resize(6);

--- a/source/ogre/settings.h
+++ b/source/ogre/settings.h
@@ -60,14 +60,14 @@ public:
 	float size_gauges, size_minimap, size_minipos, size_arrow, zoom_minimap;
 	int gauges_type, gauges_layout;
 	//  cam
-	float fov_min, fov_max, fov_smooth;
+	float fov_min, fov_boost, fov_smooth;
 	bool cam_loop_chng;  int cam_in_loop;
 	bool cam_bounce;  float cam_bnc_mul;
 	//  pacenotes
 	bool pace_show;  int pace_next;
 	float pace_dist, pace_size, pace_near, pace_alpha;
 	bool trail_show;
-	
+
 	eGraphType graphs_type;
 	int car_dbgtxtclr, car_dbgtxtcnt;
 	bool sounds_info;
@@ -103,7 +103,7 @@ public:
 	public:
 		std::string track;  bool track_user;
 		float trees;  // common
-		
+
 		bool trackreverse;
 		std::vector<std::string> car;  //[4] local players
 		std::vector<float> car_hue, car_sat, car_val, car_gloss, car_refl;  //[6] also for ghosts
@@ -117,12 +117,12 @@ public:
 
 		float boost_power, boost_max, boost_min, boost_per_km, boost_add_sec;
 		void BoostDefault();
-		
+
 		bool rpl_rec;
 		//  champ
 		int champ_num, chall_num;  // -1 none
 		bool champ_rev;
-		
+
 		float pre_time;  int start_order;
 
 		GameSet();
@@ -130,11 +130,11 @@ public:
 		gui;  // gui only config
 	//---------------
 
-	
+
 	//  misc
 	bool dev_keys, dev_no_prvs;  // dev
 	bool split_vertically;
-	
+
 	//  startup, other
 	bool bltDebug, bltLines, bltProfilerTxt, profilerTxt;
 	bool loadingbackground, show_welcome;
@@ -145,17 +145,17 @@ public:
 		vol_fl_splash,vol_fl_cont, vol_car_crash,vol_car_scrap;
 	bool snd_chk, snd_chkwr;  // play hud
 	bool snd_reverb;  std::string snd_device;
-	
+
 	//  sim freq (1/interval timestep)
 	float game_fq, blt_fq,  perf_speed;
 	int blt_iter, dyn_iter,  multi_thr, thread_sleep, gui_sleep;
-	
+
 	//  graphs vis
 	float tc_r, tc_xr;  // tire circles max
 	float te_yf, te_xfx, te_xfy, te_xf_pow;  // tire edit max
 	bool te_reference, te_common;
 
-	
+
 	//  effects
 	bool all_effects, bloom, blur, hdr;
 	float bloom_int, bloom_orig, blur_int;  // intensity
@@ -173,7 +173,7 @@ public:
 	bool rpl_ghostpar, rpl_ghostrewind, rpl_listghosts;
 	int rpl_listview, rpl_numViews;
 	float ghoHideDist, ghoHideDistTrk;  // ghost hide dist, when close
-	
+
 	//  network
 	std::string nickname, netGameName;
 	std::string master_server_address, connect_address;
@@ -182,7 +182,7 @@ public:
 	// not in gui
 	int net_local_plr;
 
-	
+
 //------------------------------------------
 	SETTINGS();
 


### PR DESCRIPTION
- Enable dynamic FOV boost by default, but make it more subtle.
- Decrease the default boost FOV value to 5 (this is equal to using 95 with the previous setup, when using the default FOV). This makes the effect more subtle.
- Change boost FOV to be additive over the default FOV, so that it can never decrease FOV when boosting.
- Remove boolean checkbox to toggle boost camera FOV. This simplifies the configuration menu slightly. If you want to disable the dynamic FOV boost effect, set the additive FOV boost to 0.0.