### PR TITLE
Decrease the dynamic camera bounce effect to 25% of its original strength

### DIFF
--- a/source/ogre/FollowCamera.cpp
+++ b/source/ogre/FollowCamera.cpp
@@ -244,7 +244,7 @@ void FollowCamera::update(Real time, const PosInfo& posIn, PosInfo* posOut, COLL
 	Vector3 pp = camPosFinal;
 	if (bounce)
 		pp += posIn.camOfs * ca->mOfsMul
-			* gPar.camBncScale * pSet->cam_bnc_mul;
+			* gPar.camBncScale * pSet->cam_bnc_mul * 0.25;
 	
 	Vector3 p = posGoal;  p.y += 1.f;  //up
 	//Vector3 d = camRotFinal * Vector3::UNIT_Z;  d.normalise();


### PR DESCRIPTION
Follow-up to https://github.com/stuntrally/stuntrally/pull/63.

This makes the effect far more subtle and less annoying during gameplay, especially on faster tracks with sudden direction changes.