### PR TITLE
Add dithering to shadowmap rendering

### DIFF
--- a/data/materials/shadows.h
+++ b/data/materials/shadows.h
@@ -1,4 +1,11 @@
-
+#ifdef SH_FRAGMENT_SHADER
+// Interleaved Gradient Noise
+// https://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare
+float quick_hash(float2 pos) {
+	const float3 magic = float3(0.06711056f, 0.00583715f, 52.9829189f);
+	return fract(magic.z * fract(dot(pos, magic.xy)));
+}
+#endif
 
 #if SHADOWS_DEPTH
 
@@ -43,6 +50,15 @@ float pssmDepthShadow(
 
 {
 	float shadow;
+
+#ifdef SH_FRAGMENT_SHADER
+	float2 dither = -float2(0.5) + quick_hash(gl_FragCoord.xy);
+	// Higher values of `dither_factor` result in a more diffuse but noisier shadow.
+	const float dither_factor = 150.0;
+	lightSpacePos0.xy += dither * invShadowmapSize0 * dither_factor;
+	lightSpacePos1.xy += dither * invShadowmapSize1 * dither_factor;
+	lightSpacePos2.xy += dither * invShadowmapSize2 * dither_factor;
+#endif
 
 	float pcf1 = depthShadowPCF(shadowMap0, lightSpacePos0, invShadowmapSize0, bias);
 	float pcf2 = depthShadowPCF(shadowMap1, lightSpacePos1, invShadowmapSize1, bias);


### PR DESCRIPTION
**Marked as draft** as this makes shadow acne issues more visible on bridges. Not sure how to resolve those – the issue is also present without this PR, but it's less obvious.

This improves shadow smoothness with only a small increase to GPU time (usually unnoticeable).

This is inspired by the shadow dithering implementation in https://github.com/godotengine/godot/pull/53967.

## Preview

*Click to view at full size. All screenshots are taken at 2560×1440. Higher resolutions will lead to a less noisy image, since the dithering will have more pixels to work with.*

![2022-06-09_01 01 41](https://user-images.githubusercontent.com/180032/172732680-126758ea-e30b-4a98-bc93-2ea5ebeb1db0.png)

![2022-06-09_01 05 23](https://user-images.githubusercontent.com/180032/172732681-06dbe961-4f4f-42f4-bfc5-d608a758a80f.png)

![2022-06-09_01 07 06](https://user-images.githubusercontent.com/180032/172732686-bcc1b5a2-7216-4a67-a6bb-3dc07f9b4e83.png)

